### PR TITLE
[PAGOPA-768] timestamp: Timestamp is valued only in the creation step

### DIFF
--- a/src/main/java/it/gov/pagopa/bizeventsdatastore/BizEventToDataStore.java
+++ b/src/main/java/it/gov/pagopa/bizeventsdatastore/BizEventToDataStore.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.bizeventsdatastore;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +55,9 @@ public class BizEventToDataStore {
         		List<BizEvent> bizEvtMsgWithProperties = new ArrayList<>();
     	        for (int i=0; i<bizEvtMsg.size(); i++) {	
     	        	BizEvent bz = bizEvtMsg.get(i);
+    	        	// set the event creation date
+    	        	bz.setTimestamp(ZonedDateTime.now().toInstant().toEpochMilli());
+    	        	// set the event associated properties
 	        		bz.setProperties(properties[i]);
 	        		bizEvtMsgWithProperties.add(bz);
     	        }

--- a/src/main/java/it/gov/pagopa/bizeventsdatastore/entity/BizEvent.java
+++ b/src/main/java/it/gov/pagopa/bizeventsdatastore/entity/BizEvent.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.bizeventsdatastore.entity;
 
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -31,8 +30,7 @@ public class BizEvent {
 	private PaymentInfo paymentInfo;
 	private List<Transfer> transferList;
 	private TransactionDetails transactionDetails;
-	@Builder.Default
-	private Long timestamp = ZonedDateTime.now().toInstant().toEpochMilli();
+	private Long timestamp;  // to be valued with ZonedDateTime.now().toInstant().toEpochMilli();
 	private Map<String, Object> properties;
 	
 	// internal management field


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- changed behavior so that timestamp is valued only in the creation step

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

- the requirement is to have the date of the first creation of the event and not the date of the last update

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- manual test 

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.